### PR TITLE
Release as zip instead

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ archives:
 - id: "terraform-provider-basexform"
   builds:
     - "terraform-provider-basexform"
-  format: tar.gz
+  format: zip
   files:
     - LICENSE
     - README.md


### PR DESCRIPTION
*Issue*
When trying to use this provider, upon `terraform init`, it throws
```
│ Error: Failed to install provider
│ Error while installing telia-oss/basexform v1.0.0: zip: not a valid zip file
```

According to [this comment](https://github.com/hashicorp/terraform/issues/26282#issuecomment-694256658), terraform only expects zip archives. Hence the proposed changes